### PR TITLE
Fixed pod error as reported by CPANTS.

### DIFF
--- a/lib/Net/LDAP/FilterBuilder.pm
+++ b/lib/Net/LDAP/FilterBuilder.pm
@@ -165,7 +165,7 @@ The value returned is an object, but stringifies to the current query:
  # prints "success"
 
 However you can refine the filter statement using three additional methods for
-the logical operations C<and>, C<or> and C<not>, as shown in the L<"SYOPSIS">
+the logical operations C<and>, C<or> and C<not>, as shown in the L<"SYNOPSIS">
 section, above, and the L<"METHODS"> section below.
 
 There are two ways to refine a filter. Either call the logic method with a new


### PR DESCRIPTION
Hi @ollyg 

Please review the PR.

https://cpants.cpanauthors.org/release/OLIVER/Net-LDAP-FilterBuilder-1.200000

            no_pod_errors
            Remove the POD errors. You can check for POD errors automatically by including Test::Pod to your test suite.

            Error: *** ERROR: unresolved internal link 'SYOPSIS' at line 167 in file Net-LDAP-FilterBuilder-1.200000/lib/Net/LDAP/FilterBuilder.pm

Many Thanks.
Best Regards,
Mohammad S Anwar